### PR TITLE
chore(ci): replace deprecated set-output workflow command (FIR-23850)

### DIFF
--- a/.github/workflows/TagIt.yml
+++ b/.github/workflows/TagIt.yml
@@ -19,14 +19,14 @@ jobs:
           FILE_NAME=${GITHUB_REPOSITORY#*/}-${GITHUB_REF##*/}
           git archive ${{ github.ref }} -o ${FILE_NAME}.zip
           git archive ${{ github.ref }} -o ${FILE_NAME}.tar.gz
-          echo "::set-output name=file_name::${FILE_NAME}"
+          echo "file_name=\"${FILE_NAME}\"" >> "${GITHUB_OUTPUT}"
       - name: Compute digests
         id: compute_digests
         run: |
-          echo "::set-output name=tgz_256::$(openssl dgst -sha256 ${{ steps.archive_project.outputs.file_name }}.tar.gz)"
-          echo "::set-output name=tgz_512::$(openssl dgst -sha512 ${{ steps.archive_project.outputs.file_name }}.tar.gz)"
-          echo "::set-output name=zip_256::$(openssl dgst -sha256 ${{ steps.archive_project.outputs.file_name }}.zip)"
-          echo "::set-output name=zip_512::$(openssl dgst -sha512 ${{ steps.archive_project.outputs.file_name }}.zip)"
+          echo "tgz_256=\"$(openssl dgst -sha256 ${{ steps.archive_project.outputs.file_name }}.tar.gz)\"" >> "${GITHUB_OUTPUT}"
+          echo "tgz_512=\"$(openssl dgst -sha512 ${{ steps.archive_project.outputs.file_name }}.tar.gz)\"" >> "${GITHUB_OUTPUT}"
+          echo "zip_256=\"$(openssl dgst -sha256 ${{ steps.archive_project.outputs.file_name }}.zip)\"" >> "${GITHUB_OUTPUT}"
+          echo "zip_512=\"$(openssl dgst -sha512 ${{ steps.archive_project.outputs.file_name }}.zip)\"" >> "${GITHUB_OUTPUT}"
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1


### PR DESCRIPTION
**Background**

[FIR-23850](https://packboard.atlassian.net/browse/FIR-23850): `set-output` was supposed to be deprecated 31 May (in 5 days). They delayed, but it needs done anyway

**Details**

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

**Testing**

It's a drop in replacement, eyeball scan for typos should do.


[FIR-23850]: https://packboard.atlassian.net/browse/FIR-23850?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ