### PR TITLE
chore(ci): pin actions versions using Ratchet tool (FIR-34388)

### DIFF
--- a/.github/workflows/TagIt.yml
+++ b/.github/workflows/TagIt.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # v4.1.7
       - name: Archive project
         id: archive_project
         run: |
@@ -29,7 +29,7 @@ jobs:
           echo "zip_512=\"$(openssl dgst -sha512 ${{ steps.archive_project.outputs.file_name }}.zip)\"" >> "${GITHUB_OUTPUT}"
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
+        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e  # v1.1.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -49,7 +49,7 @@ jobs:
           draft: false
           prerelease: false
       - name: Upload zip
-        uses: actions/upload-release-asset@v1
+        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5  # v1.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -58,7 +58,7 @@ jobs:
           asset_name: ${{ steps.archive_project.outputs.file_name }}.zip
           asset_content_type: application/zip
       - name: Upload tar.gz
-        uses: actions/upload-release-asset@v1
+        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5  # v1.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
This PR pins the dependency versions in GHA workflows to git sha based (immutable) as opposed to tag or branch based.